### PR TITLE
Make laravel-lang-installer compatible with Laravel v5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require": {
     "php": ">=5.5.9",
-    "illuminate/support": "5.1.*"
+    "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*"
   },
   "autoload": {
     "psr-4": {

--- a/src/Services/GithubResourcesRepository.php
+++ b/src/Services/GithubResourcesRepository.php
@@ -39,7 +39,7 @@ class GithubResourcesRepository implements ResourcesRepository
      */
     protected function getUrl($version, $lang, $file)
     {
-        return $this->getLocation() . '/' . $version . '/' . $lang . '/' . $file . '.php';
+        return $this->getLocation() . '/' . $version . '/src/' . $lang . '/' . $file . '.php';
     }
 
     /**


### PR DESCRIPTION
Hi Adrian,

I fixed compatibility with Laravel 5.x versions. Caouecs languages repository has been refactored since Laravel 5.2, so I fixed the download link in the `GithubResourcesRepository` by inserting the `src/` directory.

BR